### PR TITLE
[WIP] Add the december 7th roundup

### DIFF
--- a/drafts/roundup_2015_12_07.md
+++ b/drafts/roundup_2015_12_07.md
@@ -1,0 +1,42 @@
+Welcome to the first edition of IPFS Weekly!  [IPFS](https://ipfs.io/) is a new hypermedia distribution protocol, addressed by content and identities, aiming to make the web faster, safer, and more open.  In these posts, we will try to highlight some of development that happened in the past week.  For anyone looking to get involved, follow the embedded hyperlinks, search the wealth of information on [github](https://github.com/ipfs) or join us on [IRC](http://webchat.freenode.net/?channels=ipfs) (#ipfs on the Freenode network).
+
+Here are some highlights of what happened during the [December 7 Sprint](https://github.com/ipfs/pm/issues/67) :
+
+### Releases
+* @whyrusleeping  shipped IPFS version 0.3.10!  It contains [74 new commits](https://github.com/ipfs/go-ipfs/compare/v0.3.9...v0.3.10) since the previous version and you can [get it here](https://ipfs.io/docs/install/).
+* npm on IPFS!  `registry-mirror` is a new tool that enables distributed discovery of npm modules by fetching and caching the latest state of npm through IPNS.  For more info, see this [blog post](http://blog.daviddias.me/2015/12/08/stellar-module-management) by @diasdavid .
+* @jbenet released a new tool/library called [dnslink](https://github.com/jbenet/go-dnslink) that makes it easy to resolve dns links (special TXT records in a domain name that can point to paths, like an IPFS path)
+
+### Updates
+* [**(infrastructure)**](https://github.com/ipfs/infrastructure) On the infrastructure side of things, @lgierth has [bootstrapped](https://github.com/ipfs/infrastructure/pull/135) two new storage, each with 17 TB of disk space!  
+* [**(api)**](https://github.com/ipfs/api) @RichardLitt has [reached a draft 1]((https://github.com/ipfs/api/pull/13) of the much needed API documentation.
+* @harlantwood wrote a bit of [nodejs code](https://github.com/ipfs/project-repos/pull/11) that spins up a fresh IPFS node, sets it to a known ID, and publishes to IPNS using that node 
+* [**(specs)**](https://github.com/ipfs/specs) The new IPFS Linked Data (IPLD) spec is actively being iterated on in the specs repository.  Join the discussion [here!](https://github.com/ipfs/specs/pull/37)
+
+### Active stuff
+* @robcat and @fazo96 have done great work integrating IPFS with pacman (the package manager for Arch Linux).  They can now install arch packages straight from IPFS!  For more details, see [this active discussion](https://github.com/ipfs/notes/issues/84).
+* @Dignifiedquire has been working on an attractive new distribution page for IPFS, which will be the new landing page to download all things IPFS.  You can see the [latest screenshots here](https://github.com/ipfs/distributions/issues/11).
+
+### Contributors
+
+Across the entire IPFS github organization, the following people have made contributions in the past week!
+
+* Christian Couder
+* David Dias
+* Enrico Fasoli
+* Friedel Ziegelmayer
+* Harlan T Wood
+* Ian Preston
+* Jeromy
+* Juan Benet
+* Kyle Drake
+* Lars Gierth
+* RainerWasserfuhr
+* Richard Littauer
+* Teo Sartori
+
+
+    For a sneak peek at the coming week, check out the [Dec 14](https://github.com/ipfs/pm/issues/74) sprint issue
+
+    Thanks, and see you next week!
+


### PR DESCRIPTION
This is a copy of the last revison in https://github.com/ipfs/pm/issues/73

This is tagged [WIP] as I believe @jbenet wants some additional changes made before publishing.  

Unfortunately I didn't make any process on the two remaining tasks (write/find a better tool to get list of committers, and write/find a tool to get a list of all comments).  

I'm traveling and visiting family for the holidays this coming week, so I'm not sure how much I'll be online.  @RichardLitt has kindly offered to drive this if I am away.  He proposed that we combine the Dec 7th roundup with the Dec 14th roundup, which sounds like a good idea to me
