### PR TITLE
Update email subscribe links to direct to MailChimp

### DIFF
--- a/published/003-2016-Jan-12.md
+++ b/published/003-2016-Jan-12.md
@@ -2,7 +2,7 @@
 
 [IPFS](//ipfs.io/) is a new hypermedia distribution protocol, addressed by content and identities, aiming to make the web faster, safer, and more open. In these posts, we highlight some of the development that has happened in the past week. For anyone looking to get involved, follow the embedded hyperlinks, search the wealth of information on [GitHub](//github.com/ipfs) or join us on [IRC](//webchat.freenode.net/?channels=ipfs) (#ipfs on the Freenode network).
 
-If you would like to get this update as an email, sign up for our [weekly newsletter](//tinyletter.com/ipfsweekly)!
+If you would like to get this update as an email, sign up for our [weekly newsletter](http://eepurl.com/gL2Pi5)!
 
 This is a double weekly: here are some of the highlights for the [January 12th](//github.com/ipfs/pm/issues/79) and the [January 19th](https://github.com/ipfs/pm/issues/83) sprints:
 

--- a/published/004-2016-Jan-25.md
+++ b/published/004-2016-Jan-25.md
@@ -2,7 +2,7 @@
 
 [IPFS](//ipfs.io/) is a new hypermedia distribution protocol, addressed by content and identities, aiming to make the web faster, safer, and more open. In these posts, we highlight some of the development that has happened in the past week. For anyone looking to get involved, follow the embedded hyperlinks, search the wealth of information on [GitHub](//github.com/ipfs) or join us on [IRC](//webchat.freenode.net/?channels=ipfs) (#ipfs on the Freenode network).
 
-If you would like to get this update as an email, sign up for our [weekly newsletter](//tinyletter.com/ipfsweekly)!
+If you would like to get this update as an email, sign up for our [weekly newsletter](http://eepurl.com/gL2Pi5)!
 
 Here are some of the highlights for the [January 25th](//github.com/ipfs/pm/issues/84) sprint:
 

--- a/published/005-2016-Feb-1.md
+++ b/published/005-2016-Feb-1.md
@@ -2,7 +2,7 @@
 
 [IPFS](//ipfs.io/) is a new hypermedia distribution protocol, addressed by content and identities, aiming to make the web faster, safer, and more open. In these posts, we highlight some of the development that has happened in the past week. For anyone looking to get involved, follow the embedded hyperlinks, search the wealth of information on [GitHub](//github.com/ipfs) or join us on [IRC](//webchat.freenode.net/?channels=ipfs) (#ipfs on the Freenode network).
 
-If you would like to get this update as an email, sign up for our [weekly newsletter](//tinyletter.com/ipfsweekly)!
+If you would like to get this update as an email, sign up for our [weekly newsletter](http://eepurl.com/gL2Pi5)!
 
 This weekly covers the last month. Here are some of the highlights for the February sprints!
 

--- a/published/006-2016-March-7.md
+++ b/published/006-2016-March-7.md
@@ -2,7 +2,7 @@
 
 [IPFS](https://ipfs.io/) is a new hypermedia distribution protocol, addressed by content and identities, aiming to make the web faster, safer, and more open. In these posts, we highlight some of the development that has happened in the past week. For anyone looking to get involved, follow the embedded hyperlinks, search the wealth of information on [GitHub](https://github.com/ipfs) or join us on [IRC](https://webchat.freenode.net/?channels=ipfs) (#ipfs on the Freenode network).
 
-If you would like to get this update as an email, sign up for our [weekly newsletter](https://tinyletter.com/ipfsweekly)!
+If you would like to get this update as an email, sign up for our [weekly newsletter](http://eepurl.com/gL2Pi5)!
 
 Here are some of the highlights for the [first week of March](https://github.com/ipfs/pm/issues/93):
 

--- a/published/007-2016-March-13.md
+++ b/published/007-2016-March-13.md
@@ -2,7 +2,7 @@
 
 [IPFS](//ipfs.io/) is a new hypermedia distribution protocol, addressed by content and identities, aiming to make the web faster, safer, and more open. In these posts, we highlight some of the development that has happened in the past week. For anyone looking to get involved, follow the embedded hyperlinks, search the wealth of information on [GitHub](//github.com/ipfs) or join us on [IRC](//webchat.freenode.net/?channels=ipfs) (#ipfs on the Freenode network).
 
-If you would like to get this update as an email, sign up for our [weekly newsletter](//tinyletter.com/ipfsweekly)!
+If you would like to get this update as an email, sign up for our [weekly newsletter](http://eepurl.com/gL2Pi5)!
 
 Here are some of the highlights for the [second week of March](//github.com/ipfs/pm/issues/97):
 

--- a/published/008-2016-March-21.md
+++ b/published/008-2016-March-21.md
@@ -2,7 +2,7 @@
 
 [IPFS](//ipfs.io/) is a new hypermedia distribution protocol, addressed by content and identities, aiming to make the web faster, safer, and more open. In these posts, we highlight some of the development that has happened in the past week. For anyone looking to get involved, follow the embedded hyperlinks, search the wealth of information on [GitHub](//github.com/ipfs) or join us on [IRC](//webchat.freenode.net/?channels=ipfs) (#ipfs on the Freenode network).
 
-If you would like to get this update as an email, sign up for our [weekly newsletter](//tinyletter.com/ipfsweekly)!
+If you would like to get this update as an email, sign up for our [weekly newsletter](http://eepurl.com/gL2Pi5)!
 
 Here are some of the highlights for the [March 14](//github.com/ipfs/pm/issues/97) sprint:
 

--- a/published/010-2016-April-18.md
+++ b/published/010-2016-April-18.md
@@ -2,7 +2,7 @@
 
 [IPFS](https://ipfs.io/) is a new hypermedia distribution protocol, addressed by content and identities, aiming to make the web faster, safer, and more open. In these posts, we highlight some of the development that has happened in the past week. For anyone looking to get involved, follow the embedded hyperlinks, search the wealth of information on [GitHub](https://github.com/ipfs) or join us on [IRC](https://webchat.freenode.net/?channels=ipfs) (#ipfs on the Freenode network).
 
-If you would like to get this update as an email, sign up for our [weekly newsletter](https://tinyletter.com/ipfsweekly)!
+If you would like to get this update as an email, sign up for our [weekly newsletter](http://eepurl.com/gL2Pi5)!
 
 Here are some of the highlights for the time period from [April 6th through April 25th](https://github.com/ipfs/pm/issues/101).
 

--- a/published/011-2018-sep-26.md
+++ b/published/011-2018-sep-26.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://webchat.freenode.net/?channels=ipfs_) (#ipfs on the Freenode network).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/012-2018-Oct-2.md
+++ b/published/012-2018-Oct-2.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/013-2018-oct-9.md
+++ b/published/013-2018-oct-9.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/014-2018-oct-16.md
+++ b/published/014-2018-oct-16.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/015-2018-oct-23.md
+++ b/published/015-2018-oct-23.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/016-2018-oct-30.md
+++ b/published/016-2018-oct-30.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/017-2018-nov-6.md
+++ b/published/017-2018-nov-6.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/018-2018-nov-13.md
+++ b/published/018-2018-nov-13.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/019-2018-nov-20.md
+++ b/published/019-2018-nov-20.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/020-2018-nov-27.md
+++ b/published/020-2018-nov-27.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/021-2018-dec-4.md
+++ b/published/021-2018-dec-4.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/022-2018-dec-11.md
+++ b/published/022-2018-dec-11.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/023-2018-dec-18.md
+++ b/published/023-2018-dec-18.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly, and remember, we’ll be back with more news on January 8th!👋
 

--- a/published/025-2019-jan-15.md
+++ b/published/025-2019-jan-15.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/026-2019-jan-22.md
+++ b/published/026-2019-jan-22.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/027-2019-jan-29.md
+++ b/published/027-2019-jan-29.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/028-2019-feb-5.md
+++ b/published/028-2019-feb-5.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/029-2019-feb-12.md
+++ b/published/029-2019-feb-12.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/030-2019-feb-19.md
+++ b/published/030-2019-feb-19.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/031-2019-feb-26.md
+++ b/published/031-2019-feb-26.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/033-2019-mar-12.md
+++ b/published/033-2019-mar-12.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/034-2019-mar-19.md
+++ b/published/034-2019-mar-19.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/035-2019-mar-26.md
+++ b/published/035-2019-mar-26.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/036-2019-apr-2.md
+++ b/published/036-2019-apr-2.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/038-2019-apr-16.md
+++ b/published/038-2019-apr-16.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/039-2019-apr-23.md
+++ b/published/039-2019-apr-23.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/040-2019-apr-30.md
+++ b/published/040-2019-apr-30.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/041-2019-may-7.md
+++ b/published/041-2019-may-7.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/042-2019-may-14.md
+++ b/published/042-2019-may-14.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/043-2019-may-21.md
+++ b/published/043-2019-may-21.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/044-2019-may-28.md
+++ b/published/044-2019-may-28.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/045-2019-june-11.md
+++ b/published/045-2019-june-11.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/046-2019-june-18.md
+++ b/published/046-2019-june-18.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/047-2019-june-25.md
+++ b/published/047-2019-june-25.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/048-2019-july-2.md
+++ b/published/048-2019-july-2.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/050-2019-july-16.md
+++ b/published/050-2019-july-16.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/051-2019-july-23-chinese.md
+++ b/published/051-2019-july-23-chinese.md
@@ -4,7 +4,7 @@
 
 想参与其中？点击下面的一些链接，查看我们在 [GitHub](https://github.com/ipfs) 上的内容，或加入我们的 [IRC](https://riot.im/app/#/room/#ipfs:matrix.org)。
 
-想要更新你的收件箱吗? [订阅我们的每周通讯!](https://tinyletter.com/ipfsnewsletter)
+想要更新你的收件箱吗? [订阅我们的每周通讯!](http://eepurl.com/gL2Pi5)
 
 以下是自上次 IPFS 周刊以来的一些亮点。
 

--- a/published/051-2019-july-23.md
+++ b/published/051-2019-july-23.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/052-2019-july-30.md
+++ b/published/052-2019-july-30.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/053-2019-august-6.md
+++ b/published/053-2019-august-6.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/054-2019-august-13.md
+++ b/published/054-2019-august-13.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/055-2019-august-20.md
+++ b/published/055-2019-august-20.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/056-2019-august-27.md
+++ b/published/056-2019-august-27.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us on [IRC](https://riot.im/app/#/room/#ipfs:matrix.org).
 
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/057-2019-sep-3.md
+++ b/published/057-2019-sep-3.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/058-2019-sep-10.md
+++ b/published/058-2019-sep-10.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/059-2019-sep-17.md
+++ b/published/059-2019-sep-17.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/060-2019-sep-24.md
+++ b/published/060-2019-sep-24.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/061-2019-oct-1.md
+++ b/published/061-2019-oct-1.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/062-2019-oct-10.md
+++ b/published/062-2019-oct-10.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/064-2019-oct-22.md
+++ b/published/064-2019-oct-22.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/065-2019-oct-29.md
+++ b/published/065-2019-oct-29.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/066-2019-nov-5.md
+++ b/published/066-2019-nov-5.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/067-2019-nov-12.md
+++ b/published/067-2019-nov-12.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/068-2019-nov-19.md
+++ b/published/068-2019-nov-19.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/069-2019-nov-26.md
+++ b/published/069-2019-nov-26.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/070-2019-dec-3.md
+++ b/published/070-2019-dec-3.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 

--- a/published/071-2019-dec-10.md
+++ b/published/071-2019-dec-10.md
@@ -4,7 +4,7 @@ The [InterPlanetary File System (IPFS)](https://ipfs.io/) is a new hypermedia di
 
 Looking to get involved? Click on some of the links below, see what we’re up to on [GitHub](https://github.com/ipfs), or join us in [chat](https://riot.im/app/#/room/#ipfs:matrix.org).
  
-Want this update in your inbox? [Subscribe to our weekly newsletter!](https://tinyletter.com/ipfsnewsletter)
+Want this update in your inbox? [Subscribe to our weekly newsletter!](http://eepurl.com/gL2Pi5)
 
 Here are some of the highlights since the last IPFS Weekly.
 


### PR DESCRIPTION
Replacing all of the TinyLetter urls with the MailChimp sign up url.